### PR TITLE
 Data Cache - Local Storage

### DIFF
--- a/src/components/cookies-dialog.tsx
+++ b/src/components/cookies-dialog.tsx
@@ -1,0 +1,81 @@
+
+import Grid from '@mui/material/Grid';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import Typography from '@mui/material/Typography';
+import DialogActions from '@mui/material/DialogActions';
+
+import CookieIcon from '@mui/icons-material/Cookie';
+
+import { useReduxStore } from '../use/redux-store';
+
+export const CookiesDialog = () => {
+  const {
+    state: {
+      settings: { cookies }
+    },
+    updateCookiesSettings,
+    forceCookiesModal
+  } = useReduxStore();
+
+  const handleClose = (value: boolean) => {
+    updateCookiesSettings(value);
+    forceCookiesModal(false);
+  };
+
+  return (
+    <Dialog
+      open={cookies.accepted === null || cookies.forceOpen}
+      onClose={() => forceCookiesModal(false)}
+      PaperProps={{
+        style: { backgroundColor: 'white', maxWidth: 500 }
+      }}
+    >
+      <DialogTitle>
+        <Grid container alignItems="center">
+          <Grid item display="flex" alignItems="center">
+            <CookieIcon />
+          </Grid>
+          <Grid item>
+            <Typography variant="h6" style={{ marginLeft: 10 }}>
+              Guardar contenido en tu navegador
+            </Typography>
+          </Grid>
+        </Grid>
+      </DialogTitle>
+      <DialogContent>
+        <Typography variant="body1" gutterBottom>
+          Para mejorar tu experiencia de uso y permitirte usar la aplicación de una forma más eficiente, ofrecemos
+          la opción de guardar el contenido de la aplicación en tu navegador.
+        </Typography>
+        <Typography variant="body1" gutterBottom>
+          Esta información no se comparte con terceros y es almacenada únicamente en tu dispositivo.
+        </Typography>
+
+        <Typography variant="body1">
+          Puedes desactivar esta funcionalidad en cualquier momento desde la configuración de la aplicación.
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          variant="outlined"
+          onClick={() => handleClose(false)}
+          style={{ borderRadius: 5 }}
+        >
+          NO UTILIZAR
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => handleClose(true)}
+          style={{ borderRadius: 5 }}  
+        >
+          ACEPTAR USO
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+};
+
+export default CookiesDialog;

--- a/src/components/sidebar/info.tsx
+++ b/src/components/sidebar/info.tsx
@@ -10,6 +10,7 @@ import Typography from '@mui/material/Typography';
 import Divider from '@mui/material/Divider';
 
 import useAcademicSummary from '../../use/use-summary';
+import useReduxStore from '../../use/redux-store';
 
 const statistics = [
   {
@@ -46,6 +47,7 @@ type PropertiesType =
 
 export default function Info() {
   const { summary, summary_grade } = useAcademicSummary();
+  const { forceCookiesModal } = useReduxStore();
 
   const [tab, setTab] = useState(0);
 
@@ -109,6 +111,18 @@ export default function Info() {
           <a href="https://github.com/arturyepez10/indice-usb" target="_blank" rel="noopener noreferrer">
             0.9.0
           </a>
+        </Typography>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          style={{
+            textDecorationLine: "underline",
+            cursor: "pointer"
+          }}
+          width="fit-content"
+          onClick={() => forceCookiesModal(true)}
+        >
+          Política de datos
         </Typography>
       </Box>
     </>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,15 +1,18 @@
 import Grid from "@mui/material/Grid";
 import { Sidebar } from "../components/sidebar";
 import { MainContent } from "../components/main-content";
-
+import { CookiesDialog } from "../components/cookies-dialog";
 
 export const Home = () => {
 
   return (
-    <Grid container sx={{ height: { xs: '100%', sm: '100dvh' } }}>
-      <Sidebar />
-      <MainContent />
-    </Grid>
+    <>
+      <CookiesDialog />
+      <Grid container sx={{ height: { xs: '100%', sm: '100dvh' } }}>
+        <Sidebar />
+        <MainContent />
+      </Grid>
+    </>
   )
 }
 

--- a/src/store/academics.ts
+++ b/src/store/academics.ts
@@ -19,8 +19,13 @@ export interface AcademicsState {
   periods: AcademicPeriodData[];
 }
 
+const academicData = localStorage.getItem('state_data');
+
 const initialState: AcademicsState = {
-  periods: [],
+  periods: 
+    academicData
+      ? JSON.parse(academicData) as AcademicPeriodData[]
+      : [],
 };
 
 export const academicsSlice = createSlice({

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,11 +2,15 @@ import { configureStore } from "@reduxjs/toolkit";
 import settingsReducer from "./settings";
 import academicsReducer from "./academics";
 
+import { cookiesSettingsListener } from "./middleware";
+
 export const store = configureStore({
   reducer: {
     settings: settingsReducer,
     academics: academicsReducer,
   },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(cookiesSettingsListener.middleware),
 });
 
 // Infer the `RootState` and `AppDispatch` types from the store itself

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,7 +2,7 @@ import { configureStore } from "@reduxjs/toolkit";
 import settingsReducer from "./settings";
 import academicsReducer from "./academics";
 
-import { cookiesSettingsListener } from "./middleware";
+import { cookiesSettingsListener, academicDataListener } from "./middleware";
 
 export const store = configureStore({
   reducer: {
@@ -10,7 +10,7 @@ export const store = configureStore({
     academics: academicsReducer,
   },
   middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware().concat(cookiesSettingsListener.middleware),
+    getDefaultMiddleware().concat(cookiesSettingsListener.middleware, academicDataListener.middleware),
 });
 
 // Infer the `RootState` and `AppDispatch` types from the store itself

--- a/src/store/middleware.ts
+++ b/src/store/middleware.ts
@@ -1,0 +1,14 @@
+import { createListenerMiddleware } from "@reduxjs/toolkit";
+import { setCookiesState } from "./settings";
+
+export const cookiesSettingsListener = createListenerMiddleware();
+cookiesSettingsListener.startListening({
+  actionCreator: setCookiesState,
+  effect: (action) => {
+    localStorage.setItem('cookies_accepted', `${action.payload}`);
+
+    if (!action.payload) {
+      localStorage.removeItem('state_data');
+    }
+  }
+})

--- a/src/store/middleware.ts
+++ b/src/store/middleware.ts
@@ -1,5 +1,12 @@
-import { createListenerMiddleware } from "@reduxjs/toolkit";
+import { createListenerMiddleware, isAnyOf } from "@reduxjs/toolkit";
 import { setCookiesState } from "./settings";
+import {
+  setNewPeriod,
+  deletePeriod,
+  updatePeriod,
+  updatPeriodAccumulatedGrade
+} from "./academics";
+import { RootState } from ".";
 
 export const cookiesSettingsListener = createListenerMiddleware();
 cookiesSettingsListener.startListening({
@@ -12,3 +19,15 @@ cookiesSettingsListener.startListening({
     }
   }
 })
+
+export const academicDataListener = createListenerMiddleware();
+cookiesSettingsListener.startListening({
+  matcher: isAnyOf(setNewPeriod, deletePeriod, updatePeriod, updatPeriodAccumulatedGrade),
+  effect: (_, api) => {
+    const state = api.getState() as RootState;
+
+    if (state.settings.cookies.accepted) {
+      localStorage.setItem('state_data', JSON.stringify(state.academics.periods));
+    }
+  }
+});

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -9,7 +9,13 @@ export interface SettingsState {
     status: boolean;
     index: number | null;
   };
+  cookies: {
+    accepted: boolean | null;
+    forceOpen: boolean;
+  }
 }
+
+const cookiesAccepted = localStorage.getItem('cookies_accepted');
 
 const initialState: SettingsState = {
   mode: 'light',
@@ -17,6 +23,13 @@ const initialState: SettingsState = {
   editPeriod: {
     status: false,
     index: null
+  },
+  cookies: {
+    accepted:
+      cookiesAccepted
+        ? JSON.parse(cookiesAccepted) as boolean
+        : null,
+    forceOpen: false
   }
 };
 
@@ -34,10 +47,22 @@ export const settingsSlice = createSlice({
     setEditPeriod: (state, action: PayloadAction<number>) => {
       state.periodModalOpen = true
       state.editPeriod = { status: true, index: action.payload };
+    },
+    setCookiesState: (state, action: PayloadAction<boolean>) => {
+      state.cookies.accepted = action.payload;
+    },
+    setForceOpen: (state, action: PayloadAction<boolean>) => {
+      state.cookies.forceOpen = action.payload;
     }
   }
 });
 
-export const { setMode, setPeriodModalOpen, setEditPeriod } = settingsSlice.actions;
+export const {
+  setMode,
+  setPeriodModalOpen,
+  setEditPeriod,
+  setCookiesState,
+  setForceOpen
+} = settingsSlice.actions;
 
 export default settingsSlice.reducer;

--- a/src/use/redux-store.ts
+++ b/src/use/redux-store.ts
@@ -1,7 +1,13 @@
 import { useDispatch, useSelector } from "react-redux";
 
 import { RootState } from "../store";
-import { setMode, setPeriodModalOpen, setEditPeriod } from "../store/settings";
+import {
+  setMode,
+  setPeriodModalOpen,
+  setEditPeriod,
+  setCookiesState,
+  setForceOpen
+} from "../store/settings";
 import {
   AcademicPeriodData,
   setNewPeriod,
@@ -48,6 +54,14 @@ export const useReduxStore = () => {
     dispatch(updatPeriodAccumulatedGrade({ period, value }));
   };
 
+  const updateCookiesSettings = (value: boolean) => {
+    dispatch(setCookiesState(value));
+  };
+
+  const forceCookiesModal = (value: boolean) => {
+    dispatch(setForceOpen(value));
+  }
+
   return {
     state: { settings, academics },
     dispatch,
@@ -56,6 +70,8 @@ export const useReduxStore = () => {
     addAcademicPeriod,
     deleteAcademicPeriod,
     editAcademicPeriod,
-    updateAccumulatedGrade
+    updateAccumulatedGrade,
+    updateCookiesSettings,
+    forceCookiesModal
   };
 };

--- a/src/use/redux-store.ts
+++ b/src/use/redux-store.ts
@@ -75,3 +75,5 @@ export const useReduxStore = () => {
     forceCookiesModal
   };
 };
+
+export default useReduxStore;


### PR DESCRIPTION
# Summary
Add support so local storage can be used (given permission by the user) to store data of the academic periods so it can persist between sessions of use.

This is the first step to guarantee a better application performance and efficiency for the user when using it 

# List of Changes
1. Added new support for middleware in redux structure
2. Define object and settings for asking permission to store data locally in the device
3. Create dialog/modal with integrated functionality to request permission to the user for storing data
4. Add cases for data retrieval of values stored in the local storage